### PR TITLE
Fix example in `count_words()` documentation

### DIFF
--- a/R/count_words.R
+++ b/R/count_words.R
@@ -10,7 +10,7 @@
 #' @importFrom rlang .data
 #' @export
 #' @examples
-#' # word_count("test.Rmd")
+#' # count_words("test.Rmd")
 
 # Get word count
 count_words <- function(file) {


### PR DESCRIPTION
The example in the `count_words()` function seems to be an old name--not the current name.